### PR TITLE
Remove Redux-related documetation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ Each lesson includes documentation, practical examples, quizzes, and assignments
 | 09 | useEffect and useCallback | Understanding useEffect and useCallback hooks in React.js | Working with forms in React.js | [useEffect and useCallback hooks](react-hooks/Hooks.md) |
 | 10 | Custom Hooks | Custom Hooks in reactjs | Understanding Custom Hooks in React.js | [Custom Hooks in React.js]() |
 | 11 | Router | React-Router | Introduction to React-Router and their usage | [React-Router](react-router/React-Router.md) |
-| 12 | Context API | React Context API | Using Context API for state management in React.js | [Context API in React.js](contextAPI/ContextAPI.md) |
-| 13 | React-Redux-Toolkit | React-Redix-Toolkit State Management | Introduction to React-Redux-Toolkit for state management in React.js | [Redux in React.js]() |
+| 12 | Context API | React Context API | Using Context API for state management in React.js | [Context API in React.js](contextAPI/ContextAPI.md)
 
 ## Contribution Guidelines 😁
 

--- a/react-basics/README.md
+++ b/react-basics/README.md
@@ -69,9 +69,8 @@ Single Page Applications (SPAs) often require client-side routing to navigate be
 
 ## State Management
 
-As your React applications grow in complexity, you may need more advanced state management solutions. Redux and Context API are two popular options for state management in React:
+As your React applications grow in complexity, you may need more advanced state management solutions. Context API are two popular options for state management in React:
 
-- **Redux**: A predictable state container for JavaScript apps. It helps manage the state of your application in a centralized store.
 - **Context API**: A feature introduced in React 16.3 for sharing state across multiple components without using props drilling.
 
 ## Testing React Components
@@ -113,7 +112,6 @@ Once your React app is ready, you'll need to deploy it to a hosting provider to 
 
 - [React Documentation](https://reactjs.org/docs/getting-started.html): Official documentation for React.
 - [React Router Documentation](https://reactrouter.com/web/guides/quick-start): Official documentation for React Router.
-- [Redux Documentation](https://redux.js.org/introduction/getting-started): Official documentation for Redux state management.
 - [Context API Documentation](https://reactjs.org/docs/context.html): Official documentation for React Context API.
 ---
 


### PR DESCRIPTION
This pull request addresses Issue #23 : Remove React-Redux Topics from Documentation Repository.

Removed all references and sections related to React-Redux from the documentation.
Files updated:
- README.md
- react-basics/README.md